### PR TITLE
feat: 이메일 비동기 처리 및 프론트 연결 api 추가, 플랫폼 별 파티리스트 구인 글이 없을 때, 고정 값 수정

### DIFF
--- a/src/main/java/kosa/server/ServerApplication.java
+++ b/src/main/java/kosa/server/ServerApplication.java
@@ -2,8 +2,10 @@ package kosa.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kosa/server/board/controller/PostController.java
+++ b/src/main/java/kosa/server/board/controller/PostController.java
@@ -6,6 +6,7 @@ import kosa.server.board.dto.response.MyPostOneResponseDto;
 import kosa.server.board.dto.response.MyPostResponseDto;
 import kosa.server.board.dto.request.PostCreateRequestDto;
 import kosa.server.board.dto.request.PostUpdateRequestDto;
+import kosa.server.board.dto.response.PlatformPostNullResponseDto;
 import kosa.server.board.dto.response.PlatformPostResponseDto;
 import kosa.server.board.service.PostService;
 import kosa.server.member.service.MemberService;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -80,6 +80,12 @@ public class PostController {
     public ResponseEntity<List<PlatformPostResponseDto>> platformPostList(@PathVariable Long platformId) {
         List<PlatformPostResponseDto> platformPostResponseDtos = postService.platformPostList(platformId);
         return new ResponseEntity<>(platformPostResponseDtos, HttpStatus.OK);
+    }
+
+    @GetMapping("/platform/{platformId}/")
+    public ResponseEntity<PlatformPostNullResponseDto> platformPostNull(@PathVariable Long platformId) {
+        PlatformPostNullResponseDto platformPostNulls = postService.platformPostNull(platformId);
+        return new ResponseEntity<>(platformPostNulls, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/kosa/server/board/dto/response/MailSendDto.java
+++ b/src/main/java/kosa/server/board/dto/response/MailSendDto.java
@@ -1,0 +1,16 @@
+package kosa.server.board.dto.response;
+
+import kosa.server.member.entity.Member;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MailSendDto {
+    private List<Member> members;
+    private String platFormName;
+    private int partySize;
+    private Long postId;
+}

--- a/src/main/java/kosa/server/board/dto/response/MailTargetResponseDto.java
+++ b/src/main/java/kosa/server/board/dto/response/MailTargetResponseDto.java
@@ -1,0 +1,14 @@
+package kosa.server.board.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MailTargetResponseDto {
+        private final String email;
+        private final String platformName;
+        private final String postUrl;
+        private final int partySize;
+
+}

--- a/src/main/java/kosa/server/board/dto/response/PlatformPostNullResponseDto.java
+++ b/src/main/java/kosa/server/board/dto/response/PlatformPostNullResponseDto.java
@@ -1,0 +1,13 @@
+package kosa.server.board.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class PlatformPostNullResponseDto {
+    private String platformName;
+    private BigDecimal platformPrice;
+}

--- a/src/main/java/kosa/server/board/repository/PartyMemberRepository.java
+++ b/src/main/java/kosa/server/board/repository/PartyMemberRepository.java
@@ -18,6 +18,8 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> 
     void deleteAllByPost_Id(Long postId);
     void deleteByPost_IdAndMember_Id(Long postId, Long memberId);
 
+    List<PartyMember> findByPostId(Long postId);
+
     @Query("SELECT pm FROM PartyMember pm " +
             "JOIN FETCH pm.member " +
             "WHERE pm.post.id = (SELECT cr.post.id FROM ChatRoom cr WHERE cr.id = :roomId)")

--- a/src/main/java/kosa/server/board/service/PostService.java
+++ b/src/main/java/kosa/server/board/service/PostService.java
@@ -1,11 +1,8 @@
 package kosa.server.board.service;
 
-import kosa.server.board.dto.response.MyPostOneResponseDto;
-import kosa.server.board.dto.response.MyPostResponseDto;
+import kosa.server.board.dto.response.*;
 import kosa.server.board.dto.request.PostCreateRequestDto;
 import kosa.server.board.dto.request.PostUpdateRequestDto;
-import kosa.server.board.dto.response. PartyMemberDto;
-import kosa.server.board.dto.response.PlatformPostResponseDto;
 import kosa.server.board.entity.PartyMember;
 import kosa.server.board.entity.Platform;
 import kosa.server.board.entity.Post;
@@ -21,15 +18,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -91,12 +84,12 @@ public class PostService {
             editor.hostId(request.getHostId());
         }
         // todo 프론트에서 인원수와 개월 수를 바꾸지 않는다면 -1을 보내주기로
-//        if (request.getCapacity() != -1) {
-//            editor.capacity(request.getCapacity());
-//        }
-//        if (request.getDurationMonth() != -1) {
-//            editor.durationMonth(request.getDurationMonth());
-//        }
+        if (request.getCapacity() != 0) {
+            editor.capacity(request.getCapacity());
+        }
+        if (request.getDurationMonth() != 0) {
+            editor.durationMonth(request.getDurationMonth());
+        }
         postToUpdate.edit(editor.build());
     }
 
@@ -258,4 +251,16 @@ public class PostService {
                 .isExpired(post.getIsExpired())
                 .build()).toList();
     }
+
+    public PlatformPostNullResponseDto platformPostNull(Long platformId) {
+        Platform platform = platformRepository.findById(platformId)
+                .orElseThrow(()->new IllegalArgumentException("로그인 아이디 정보가 없습니다."));
+
+        return PlatformPostNullResponseDto.builder()
+                .platformName(platform.getName())
+                .platformPrice(platform.getPrice())
+                .build();
+    }
+
+
 }

--- a/src/main/java/kosa/server/mail/controller/MailController.java
+++ b/src/main/java/kosa/server/mail/controller/MailController.java
@@ -1,0 +1,26 @@
+package kosa.server.mail.controller;
+
+import jakarta.mail.MessagingException;
+import kosa.server.board.dto.response.MailSendDto;
+import kosa.server.mail.service.MailService;
+import kosa.server.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class MailController {
+    private final MailService mailService;
+
+    @GetMapping("/mailSend/{postId}")
+    public ResponseEntity<?> sendMail(@PathVariable Long postId)
+                                            throws MessagingException, UnsupportedEncodingException {
+        mailService.prepareAndSendMail(postId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/kosa/server/mail/service/MailService.java
+++ b/src/main/java/kosa/server/mail/service/MailService.java
@@ -3,12 +3,18 @@ package kosa.server.mail.service;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeUtility;
+import kosa.server.board.dto.response.MailTargetResponseDto;
+import kosa.server.board.entity.PartyMember;
+import kosa.server.board.repository.PartyMemberRepository;
+import kosa.server.board.repository.PostRepository;
+import kosa.server.board.service.PostService;
 import kosa.server.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
@@ -22,31 +28,44 @@ public class MailService {
 
     @Qualifier("notificationMailSender")
     private final JavaMailSender notificationMailSender;
+    private final PartyMemberRepository partyMemberRepository;
     @Value("${spring.mail.username}")
     private String fixedServiceSenderEmail;
     private final SpringTemplateEngine templateEngine;
 
+    // 동기 메서드: 데이터 준비
+    public void prepareAndSendMail(Long postId) throws UnsupportedEncodingException, MessagingException {
+        List<PartyMember> members = partyMemberRepository.findByPostId(postId);
+        List<MailTargetResponseDto> targets = members.stream()
+                .map(m -> new MailTargetResponseDto(
+                        m.getMember().getEmail(),
+                        m.getPost().getPlatform().getName(),
+                        "http://localhost:8080/post/" + postId,
+                        m.getPost().getPartySize()
+                ))
+                .toList();
+        sendMail(targets); // 비동기 메서드 호출
+    }
+
     //구인글 모집이 완료되었을 때 사용할 메서드
-    public void sendMail(List<Member> members, String platFormName, int partySize, Long postId)
+    @Async
+    public void sendMail(List<MailTargetResponseDto> targets)
                                         throws UnsupportedEncodingException, MessagingException {
-
-        String postUrl = "http://localhost:8080/post/" + postId;
-
-        for (Member member : members) {
+        for (MailTargetResponseDto target : targets) {
             MimeMessage message = notificationMailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
             // 템플릿 context 세팅
             Context context = new Context();
-            context.setVariable("ottName", platFormName);
-            context.setVariable("postUrl", postUrl);
-            context.setVariable("partySize", partySize);
+            context.setVariable("ottName", target.getPlatformName());
+            context.setVariable("postUrl", target.getPostUrl());
+            context.setVariable("partySize", target.getPartySize());
 
             String html = templateEngine.process("email-alert", context);
 
-            helper.setTo(member.getEmail());
+            helper.setTo(target.getEmail());
             helper.setFrom(fixedServiceSenderEmail);
-            helper.setSubject(MimeUtility.encodeText("[OTT Moa] '" + platFormName + "' 파티 모집이 완료되었습니다.", "UTF-8", "B"));
+            helper.setSubject(MimeUtility.encodeText("[OTT Moa] '" + target.getPlatformName() + "' 파티 모집이 완료되었습니다.", "UTF-8", "B"));
 
             helper.setText(html, true);
 

--- a/src/test/java/kosa/server/mail/service/MailServiceTest.java
+++ b/src/test/java/kosa/server/mail/service/MailServiceTest.java
@@ -62,10 +62,10 @@ class MailServiceTest {
         Long fakePostId = 999L;
 
         // when
-        mailService.sendMail(members, platform, partySize, fakePostId);
+        mailService.prepareAndSendMail(fakePostId);
 
         // then
-        verify(mailService, times(1)).sendMail(members, platform, partySize, fakePostId);
+        verify(mailService, times(1)).prepareAndSendMail(fakePostId);
 
         verifyNoMoreInteractions(mailService);
     }


### PR DESCRIPTION
1. 파티 가입 시 파티방 안에 있는 모든 사람에게 이메일 전송
2. 이메일 전송시, 3명이상부터 전송이 오래걸려 프론트에서 반응이 늦어지는 것을 확인, 단순 전송이다보니 이메일 비동기 처리.
3. 플랫폼 파티리스트 나열할 때 구인 글이 없으면 wavve로 고정되어 있어서 변경