### PR TITLE
fix: 상세 페이지 플랫폼 가격 소숫점 한자리 올림, 시작된 파티는 목록에서 안보이게 하기

### DIFF
--- a/src/main/java/kosa/server/board/dto/response/PlatformPostResponseDto.java
+++ b/src/main/java/kosa/server/board/dto/response/PlatformPostResponseDto.java
@@ -16,6 +16,7 @@ public class PlatformPostResponseDto {
     private int currentCount;
     private int partySize;
     private String isExpired;
+    private LocalDateTime startDate;
     private LocalDateTime createdAt;
 
 }

--- a/src/main/java/kosa/server/board/service/PostService.java
+++ b/src/main/java/kosa/server/board/service/PostService.java
@@ -235,7 +235,7 @@ public class PostService {
         return MyPostOneResponseDto.builder()
                 .postId(posts.getId())
                 .platformName(posts.getPlatform().getName())
-                .price(posts.getPlatform().getPrice())
+                .price(posts.getPlatform().getPrice().divide(BigDecimal.valueOf(posts.getPartySize()), 0, BigDecimal.ROUND_HALF_UP))
                 .currentCount(posts.getCurrentCount())
                 .partySize(posts.getPartySize())
                 .durationMonth(posts.getDurationMonth())
@@ -264,6 +264,7 @@ public class PostService {
                 .currentCount(post.getCurrentCount())
                 .partySize(post.getPartySize())
                 .isExpired(post.getIsExpired())
+                .startDate(post.getStartDate())
                 .createdAt(post.getCreatedAt())
                 .build()).toList();
     }


### PR DESCRIPTION
- 상세 페이지 플랫폼 가격 올림처리
- 구독 시작버튼 누르면 플랫폼 별 파티 리스트에서 파티방 보이지 않도록 변경