### PR TITLE
feat: 파티 가입 동시성 문제 해결을 위한 비관적 락 적용

### DIFF
--- a/src/main/java/kosa/server/board/entity/Platform.java
+++ b/src/main/java/kosa/server/board/entity/Platform.java
@@ -1,6 +1,8 @@
 package kosa.server.board.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +10,9 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+@Builder
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 @Entity
 public class Platform {

--- a/src/main/java/kosa/server/board/repository/PostRepository.java
+++ b/src/main/java/kosa/server/board/repository/PostRepository.java
@@ -4,9 +4,13 @@ import kosa.server.board.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -39,4 +43,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByIsExpired(String isExpired);
 
     List<Post> findByPlatformId(Long platformId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Post p WHERE p.id = :id")
+    Optional<Post> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/kosa/server/board/service/PostService.java
+++ b/src/main/java/kosa/server/board/service/PostService.java
@@ -15,6 +15,7 @@ import kosa.server.mail.service.MailService;
 import kosa.server.member.entity.Member;
 import kosa.server.member.exception.InvalidArgumentException;
 import kosa.server.member.exception.MemberNotFoundException;
+import kosa.server.member.exception.PartyFullException;
 import kosa.server.member.repository.jpa.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -124,20 +125,28 @@ public class PostService {
     public void joinParty(String loginId, Long postId) {
         Member member = memberJpaRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new InvalidArgumentException(ErrorCode.MEMBER_NOT_FOUND));
-        Post post = postRepository.findById(postId)
-                .orElseThrow(()->new InvalidArgumentException(ErrorCode.POST_NOT_FOUND));
+        
+        // 비관적 락으로 Post 조회
+        Post post = postRepository.findByIdWithLock(postId)
+                .orElseThrow(() -> new InvalidArgumentException(ErrorCode.POST_NOT_FOUND));
+
+        // 파티 정원 체크
+        if (post.getCurrentCount() >= post.getPartySize()) {
+            throw new PartyFullException(ErrorCode.PARTY_FULL);
+        }
+
+        // 이미 가입했는지 체크
+        boolean alreadyJoined = post.getPartyMember().stream()
+                .anyMatch(pm -> pm.getMember().equals(member));
+        if (alreadyJoined) {
+            throw new InvalidArgumentException(ErrorCode.PARTY_ALREADY_JOINED);
+        }
 
         PartyMember partyMember = PartyMember.builder()
                 .post(post)
                 .member(member)
                 .isOwner("N")
                 .build();
-
-        boolean alreadyJoined = post.getPartyMember().stream()
-                .anyMatch(pm -> pm.getMember().equals(member));
-        if (alreadyJoined) {
-            throw new InvalidArgumentException(ErrorCode.PARTY_ALREADY_JOINED);
-        }
 
         post.setCurrentCount(post.getCurrentCount() + 1);
         partyMemberRepository.save(partyMember);

--- a/src/main/java/kosa/server/common/code/ErrorCode.java
+++ b/src/main/java/kosa/server/common/code/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     // Post (5xxx)
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "포스트를 찾을 수 없습니다."),
     PARTY_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "P002", "이미 파티에 가입되어 있습니다."),
-    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "P003", "구독 정보가 없습니다.");
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "P003", "구독 정보가 없습니다."),
+    PARTY_FULL(HttpStatus.BAD_REQUEST, "P004", "파티 정원이 가득 찼습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kosa/server/member/exception/PartyFullException.java
+++ b/src/main/java/kosa/server/member/exception/PartyFullException.java
@@ -1,0 +1,15 @@
+package kosa.server.member.exception;
+
+import kosa.server.common.code.ErrorCode;
+
+/**
+ * 정원 체크 시 파티가 다 찼을 때 발생하는 예외
+ */
+public class PartyFullException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public PartyFullException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/test/java/kosa/server/board/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/kosa/server/board/service/PostServiceConcurrencyTest.java
@@ -1,0 +1,225 @@
+package kosa.server.board.service;
+
+import kosa.server.board.entity.Platform;
+import kosa.server.board.entity.Post;
+import kosa.server.board.repository.PartyMemberRepository;
+import kosa.server.board.repository.PlatformRepository;
+import kosa.server.board.repository.PostRepository;
+import kosa.server.member.entity.Member;
+import kosa.server.member.entity.Role;
+import kosa.server.member.enums.RoleType;
+import kosa.server.member.exception.PartyFullException;
+import kosa.server.member.repository.jpa.MemberJpaRepository;
+import kosa.server.member.repository.jpa.RoleJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PostServiceConcurrencyTest {
+
+    @Autowired
+    private PostService postService;
+    
+    @Autowired
+    private PostRepository postRepository;
+    
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+    
+    @Autowired
+    private PlatformRepository platformRepository;
+    
+    @Autowired
+    private PartyMemberRepository partyMemberRepository;
+    
+    @Autowired
+    private RoleJpaRepository roleJpaRepository;
+
+    private Member testOwner;
+    private Platform testPlatform;
+    private Role userRole;
+
+    @BeforeEach
+    void setUp() {
+        // 실제 DB에 데이터 저장
+        userRole = Role.builder()
+                .roleName(RoleType.USER.getKey())
+                .build();
+        roleJpaRepository.save(userRole);
+
+        testOwner = Member.builder()
+                .loginId("owner123")
+                .password("password")
+                .nickname("파티장")
+                .name("테스트유저")
+                .email("owner@test.com")
+                .role(userRole)
+                .enabled(true)
+                .build();
+        memberJpaRepository.save(testOwner);
+
+        testPlatform = Platform.builder()
+                .name("Netflix")
+                .category(1)
+                .capacity(4)
+                .price(BigDecimal.valueOf(15000))
+                .build();
+        platformRepository.save(testPlatform);
+    }
+
+    @Test
+    @DisplayName("동시에 여러 사용자가 파티 가입을 시도할 때 비관적 락으로 정원을 초과하지 않는다")
+    void joinParty_concurrencyTestWithPessimisticLock() throws InterruptedException {
+        // given - 정원 3명인 파티 생성 (파티장 포함하여 2명 더 가입 가능)
+        Post post = Post.builder()
+                .platform(testPlatform)
+                .member(testOwner)
+                .current_count(1) // 파티장만 있는 상태
+                .partySize(3)     // 최대 정원 3명
+                .durationMonth(1)
+                .hostId("host123")
+                .hostPwd("hostpwd")
+                .isExpired("N")
+                .build();
+        Post savedPost = postRepository.save(post);
+
+        // 5명의 테스트 회원 생성
+        for (int i = 1; i <= 5; i++) {
+            Member member = Member.builder()
+                    .loginId("user" + i)
+                    .password("password")
+                    .nickname("회원" + i)
+                    .name("테스트" + i)
+                    .email("user" + i + "@test.com")
+                    .role(userRole)
+                    .enabled(true)
+                    .build();
+            memberJpaRepository.save(member);
+        }
+
+        // when - 5명이 동시에 가입 시도
+        int threadCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        for (int i = 1; i <= threadCount; i++) {
+            final String loginId = "user" + i;
+            executorService.submit(() -> {
+                try {
+                    postService.joinParty(loginId, savedPost.getId());
+                    successCount.incrementAndGet();
+                } catch (PartyFullException e) {
+                    failCount.incrementAndGet();
+                } catch (Exception e) {
+                    // 다른 예외는 실패로 처리
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then - 비관적 락으로 정원 2명만 성공하고 나머지는 실패해야 함
+        assertThat(successCount.get()).isEqualTo(2); // 파티장 제외하고 2명만 가입 성공
+        assertThat(failCount.get()).isEqualTo(3);   // 나머지 3명은 실패
+
+        // DB에서 실제 currentCount 확인
+        Post updatedPost = postRepository.findById(savedPost.getId()).orElse(null);
+        assertThat(updatedPost).isNotNull();
+        assertThat(updatedPost.getCurrentCount()).isEqualTo(3); // 파티장 + 2명
+        
+        // PartyMember 테이블에서도 확인
+        long memberCount = partyMemberRepository.findByPostId(savedPost.getId()).size();
+        assertThat(memberCount).isEqualTo(2); // 파티장 제외하고 2명의 PartyMember
+    }
+
+    @Test
+    @DisplayName("정원이 1명 남았을 때 여러 명이 동시 가입 시도하면 1명만 성공한다")
+    void joinParty_onlyOneSlotLeft_shouldAllowOnlyOneUser() throws InterruptedException {
+        // given - 정원 4명 중 3명이 이미 가입한 상태 (1자리만 남음)
+        Post post = Post.builder()
+                .platform(testPlatform)
+                .member(testOwner)
+                .current_count(3) // 3명 이미 가입
+                .partySize(4)     // 최대 정원 4명
+                .durationMonth(1)
+                .hostId("host123")
+                .hostPwd("hostpwd")
+                .isExpired("N")
+                .build();
+        Post savedPost = postRepository.save(post);
+
+        // 3명의 테스트 회원 생성
+        for (int i = 1; i <= 3; i++) {
+            Member member = Member.builder()
+                    .loginId("competitor" + i)
+                    .password("password")
+                    .nickname("경쟁자" + i)
+                    .name("테스트경쟁자" + i)
+                    .email("competitor" + i + "@test.com")
+                    .role(userRole)
+                    .enabled(true)
+                    .build();
+            memberJpaRepository.save(member);
+        }
+
+        // when - 3명이 동시에 마지막 자리를 두고 경쟁
+        int threadCount = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        for (int i = 1; i <= threadCount; i++) {
+            final String loginId = "competitor" + i;
+            executorService.submit(() -> {
+                try {
+                    postService.joinParty(loginId, savedPost.getId());
+                    successCount.incrementAndGet();
+                } catch (PartyFullException e) {
+                    failCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then - 1명만 성공하고 나머지는 실패
+        assertThat(successCount.get()).isEqualTo(1); // 1명만 성공
+        assertThat(failCount.get()).isEqualTo(2);   // 2명은 실패
+
+        // DB 확인
+        Post updatedPost = postRepository.findById(savedPost.getId()).orElse(null);
+        assertThat(updatedPost).isNotNull();
+        assertThat(updatedPost.getCurrentCount()).isEqualTo(4); // 정원 가득참
+        
+        // PartyMember 확인
+        long memberCount = partyMemberRepository.findByPostId(savedPost.getId()).size();
+        assertThat(memberCount).isEqualTo(1); // 새로 가입한 1명만
+    }
+}

--- a/src/test/java/kosa/server/board/service/PostServiceTest.java
+++ b/src/test/java/kosa/server/board/service/PostServiceTest.java
@@ -1,0 +1,195 @@
+package kosa.server.board.service;
+
+import kosa.server.board.entity.PartyMember;
+import kosa.server.board.entity.Platform;
+import kosa.server.board.entity.Post;
+import kosa.server.board.repository.PartyMemberRepository;
+import kosa.server.board.repository.PlatformRepository;
+import kosa.server.board.repository.PostRepository;
+import kosa.server.member.entity.Member;
+import kosa.server.member.entity.Role;
+import kosa.server.member.enums.RoleType;
+import kosa.server.member.exception.PartyFullException;
+import kosa.server.member.repository.jpa.MemberJpaRepository;
+import kosa.server.member.repository.jpa.RoleJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+    
+    @Mock
+    private MemberJpaRepository memberJpaRepository;
+    
+    @Mock
+    private PlatformRepository platformRepository;
+    
+    @Mock
+    private PartyMemberRepository partyMemberRepository;
+    
+    @Mock
+    private RoleJpaRepository roleJpaRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    private Member testOwner;
+    private Platform testPlatform;
+    private Role userRole;
+
+    @BeforeEach
+    void setUp() {
+        // Mock 데이터 준비
+        userRole = Role.builder()
+                .roleName(RoleType.USER.getKey())
+                .build();
+
+        testOwner = Member.builder()
+                .loginId("owner123")
+                .password("password")
+                .nickname("파티장")
+                .name("테스트유저")
+                .email("owner@test.com")
+                .role(userRole)
+                .enabled(true)
+                .build();
+
+        testPlatform = Platform.builder()
+                .name("Netflix")
+                .category(1)
+                .capacity(4)
+                .price(BigDecimal.valueOf(15000))
+                .build();
+    }
+
+    @Test
+    @DisplayName("파티 정원 초과 시 PartyFullException이 발생한다")
+    void joinParty_shouldThrowExceptionWhenPartyIsFull() {
+        // given - 정원이 가득 찬 파티
+        Post fullPost = Post.builder()
+                .platform(testPlatform)
+                .member(testOwner)
+                .current_count(3) // 정원 가득참
+                .partySize(3)     // 최대 정원 3명
+                .durationMonth(1)
+                .hostId("host123")
+                .hostPwd("hostpwd")
+                .isExpired("N")
+                .build();
+        ReflectionTestUtils.setField(fullPost, "id", 1L);
+
+        Member newMember = Member.builder()
+                .loginId("newuser")
+                .password("password")
+                .nickname("신규회원")
+                .name("테스트신규")
+                .email("new@test.com")
+                .role(userRole)
+                .enabled(true)
+                .build();
+
+        // Mock 설정
+        when(memberJpaRepository.findByLoginId("newuser")).thenReturn(Optional.of(newMember));
+        when(postRepository.findByIdWithLock(1L)).thenReturn(Optional.of(fullPost));
+
+        // when & then
+        assertThatThrownBy(() -> postService.joinParty("newuser", 1L))
+                .isInstanceOf(PartyFullException.class);
+                
+        // 파티 가득참으로 인해 save 호출되지 않음
+        verify(partyMemberRepository, never()).save(any(PartyMember.class));
+        // currentCount 변경되지 않음
+        assertThat(fullPost.getCurrentCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("정상적인 파티 가입 시 currentCount가 증가하고 PartyMember가 저장된다")
+    void joinParty_shouldSucceedWithAvailableSpace() {
+        // given - 여유 있는 파티
+        Post availablePost = Post.builder()
+                .platform(testPlatform)
+                .member(testOwner)
+                .current_count(1) // 파티장만 있음
+                .partySize(4)     // 최대 정원 4명
+                .durationMonth(1)
+                .hostId("host123")
+                .hostPwd("hostpwd")
+                .isExpired("N")
+                .build();
+        ReflectionTestUtils.setField(availablePost, "id", 1L);
+
+        Member newMember = Member.builder()
+                .loginId("normaluser")
+                .password("password")
+                .nickname("일반회원")
+                .name("테스트일반")
+                .email("normal@test.com")
+                .role(userRole)
+                .enabled(true)
+                .build();
+
+        // Mock 설정
+        when(memberJpaRepository.findByLoginId("normaluser")).thenReturn(Optional.of(newMember));
+        when(postRepository.findByIdWithLock(1L)).thenReturn(Optional.of(availablePost));
+
+        // when
+        assertThatNoException().isThrownBy(() -> postService.joinParty("normaluser", 1L));
+
+        // then
+        assertThat(availablePost.getCurrentCount()).isEqualTo(2); // 파티장 + 1명
+        verify(partyMemberRepository, times(1)).save(any(PartyMember.class));
+    }
+
+    @Test
+    @DisplayName("비관적 락을 사용하여 Post를 조회한다")
+    void joinParty_shouldUsePessimisticLock() {
+        // given
+        Post post = Post.builder()
+                .platform(testPlatform)
+                .member(testOwner)
+                .current_count(1)
+                .partySize(4)
+                .durationMonth(1)
+                .hostId("host123")
+                .hostPwd("hostpwd")
+                .isExpired("N")
+                .build();
+        ReflectionTestUtils.setField(post, "id", 1L);
+
+        Member member = Member.builder()
+                .loginId("testuser")
+                .password("password")
+                .nickname("테스트유저")
+                .name("테스트")
+                .email("test@test.com")
+                .role(userRole)
+                .enabled(true)
+                .build();
+
+        // Mock 설정
+        when(memberJpaRepository.findByLoginId("testuser")).thenReturn(Optional.of(member));
+        when(postRepository.findByIdWithLock(1L)).thenReturn(Optional.of(post));
+
+        // when
+        postService.joinParty("testuser", 1L);
+
+        // then - 비관적 락 메서드가 호출되었는지 확인
+        verify(postRepository, times(1)).findByIdWithLock(1L);
+        verify(postRepository, never()).findById(1L); // 일반 findById는 호출되지 않음
+    }
+}

--- a/src/test/java/kosa/server/config/JpaAuditingConfig.java
+++ b/src/test/java/kosa/server/config/JpaAuditingConfig.java
@@ -1,9 +1,0 @@
-package kosa.server.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@EnableJpaAuditing
-@Configuration
-public class JpaAuditingConfig {
-}

--- a/src/test/java/kosa/server/mail/service/MailServiceTest.java
+++ b/src/test/java/kosa/server/mail/service/MailServiceTest.java
@@ -1,101 +1,128 @@
 package kosa.server.mail.service;
 
-import jakarta.mail.Address;
-import jakarta.mail.BodyPart;
-import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.internet.MimeMultipart;
-import kosa.server.member.entity.Member;
-import org.junit.jupiter.api.*;
+import kosa.server.board.dto.response.MailTargetResponseDto;
+import kosa.server.board.repository.PartyMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MailServiceTest {
 
     @Mock
+    private JavaMailSender notificationMailSender;
+
+    @Mock
+    private PartyMemberRepository partyMemberRepository;
+
+    @Mock
+    private SpringTemplateEngine templateEngine;
+
+    @Mock
+    private MimeMessage mimeMessage;
+
+    @InjectMocks
     private MailService mailService;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        // @Value로 주입되는 필드를 직접 설정
+        ReflectionTestUtils.setField(mailService, "fixedServiceSenderEmail", "test@example.com");
     }
 
     @Test
-    @DisplayName("메일을 보낼 수 있다.")
-    void sendMail() throws MessagingException, IOException {
+    @DisplayName("메일을 정상적으로 발송할 수 있다")
+    void sendMail_shouldSendEmailSuccessfully() throws MessagingException, UnsupportedEncodingException {
         // given
-        Member member1  = Member.builder()
-                .email("ghyunjin0913@naver.com")
-                .name("테스트유저1")
-                .build();
-        Member member2 = Member.builder()
-                .email("ghyunjin0913@gmail.com")
-                .name("테스트유저2")
-                .build();
-        List<Member> members = List.of(member1, member2);
+        MailTargetResponseDto target1 = new MailTargetResponseDto(
+                "user1@test.com",
+                "Netflix",
+                "http://localhost:3000/post/1",
+                4
+        );
 
-        String platform = "넷플릭스";
-        int partySize = 2;
-        Long fakePostId = 999L;
+        MailTargetResponseDto target2 = new MailTargetResponseDto(
+                "user2@test.com",
+                "Netflix",
+                "http://localhost:3000/post/1",
+                4
+        );
+
+        List<MailTargetResponseDto> targets = List.of(target1, target2);
+
+        // Mock 설정
+        when(notificationMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(templateEngine.process(eq("email-alert"), any(Context.class))).thenReturn("<html>Test HTML</html>");
+
+        // when & then
+        assertThatNoException().isThrownBy(() -> mailService.sendMail(targets));
+
+        // verify
+        verify(notificationMailSender, times(2)).createMimeMessage(); // 2개의 메일이므로 2번 호출
+        verify(notificationMailSender, times(2)).send(mimeMessage);   // 2번 전송
+        verify(templateEngine, times(2)).process(eq("email-alert"), any(Context.class)); // 2번 템플릿 처리
+    }
+
+    @Test
+    @DisplayName("빈 리스트일 때는 메일을 발송하지 않는다")
+    void sendMail_shouldNotSendWhenListIsEmpty() throws MessagingException, UnsupportedEncodingException {
+        // given
+        List<MailTargetResponseDto> emptyTargets = List.of();
+
+        // when & then
+        assertThatNoException().isThrownBy(() -> mailService.sendMail(emptyTargets));
+
+        // verify
+        verify(notificationMailSender, never()).createMimeMessage();
+        verify(notificationMailSender, never()).send(any(MimeMessage.class));
+        verify(templateEngine, never()).process(anyString(), any(Context.class));
+    }
+
+    @Test
+    @DisplayName("템플릿 처리 시 올바른 변수가 전달된다")
+    void sendMail_shouldPassCorrectVariablesToTemplate() throws MessagingException, UnsupportedEncodingException {
+        // given
+        MailTargetResponseDto target = new MailTargetResponseDto(
+                "test@example.com",
+                "Disney+",
+                "http://localhost:3000/post/123",
+                3
+        );
+
+        List<MailTargetResponseDto> targets = List.of(target);
+
+        // Mock 설정
+        when(notificationMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(templateEngine.process(eq("email-alert"), any(Context.class))).thenReturn("<html>Test HTML</html>");
 
         // when
-        mailService.prepareAndSendMail(fakePostId);
+        mailService.sendMail(targets);
 
-        // then
-        verify(mailService, times(1)).prepareAndSendMail(fakePostId);
-
-        verifyNoMoreInteractions(mailService);
+        // then - ArgumentCaptor를 사용하여 Context 내용 검증
+        ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+        
+        verify(templateEngine).process(eq("email-alert"), contextCaptor.capture());
+        
+        Context capturedContext = contextCaptor.getValue();
+        assertThat(capturedContext.getVariable("ottName")).isEqualTo("Disney+");
+        assertThat(capturedContext.getVariable("postUrl")).isEqualTo("http://localhost:3000/post/123");
+        assertThat(capturedContext.getVariable("partySize")).isEqualTo(3);
     }
 }
-
-
-
-/*@SpringBootTest
-@ActiveProfiles("test")
-public class MailServiceTest {
-
-    @Autowired
-    private MailService mailService;
-
-    @Test
-    void setMail() throws InterruptedException, MessagingException, UnsupportedEncodingException {
-        // given
-        Member member = Member.builder()
-                .email("ghyunjin0913@naver.com")
-                .name("테스트유저")
-                .build();
-        List<Member> members = List.of(member);
-
-        // when
-        mailService.sendMail(members, "Netflix", 1, 999L);
-
-        // then
-        assertDoesNotThrow(() ->
-                mailService.sendMail(members, "Netflix", 4, 123L)
-        );
-    }
-}*/
-


### PR DESCRIPTION
- Post 엔티티 조회 시 PESSIMISTIC_WRITE 락 구현
- 파티 정원 검증 로직 및 PartyFullException 처리 추가
- CountDownLatch를 활용한 동시성 테스트 추가
- MailService 테스트의 Mockito 설정 수정