### PR TITLE
refactor: GlobalExceptionHandler 리팩토링 및 커스텀 예외 통합 처리

### DIFF
--- a/src/main/java/kosa/server/auth/controller/AuthController.java
+++ b/src/main/java/kosa/server/auth/controller/AuthController.java
@@ -17,7 +17,7 @@ import kosa.server.common.code.ErrorCode;
 import kosa.server.common.security.jwt.JwtProvider;
 import kosa.server.common.security.user.CustomUserPrincipal;
 import kosa.server.common.util.CookieUtil;
-import kosa.server.member.exception.TokenNotFoundException;
+import kosa.server.auth.exception.TokenNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/kosa/server/auth/exception/DuplicateEmailException.java
+++ b/src/main/java/kosa/server/auth/exception/DuplicateEmailException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.auth.exception;
 
 import kosa.server.common.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/kosa/server/auth/exception/DuplicateLoginIdException.java
+++ b/src/main/java/kosa/server/auth/exception/DuplicateLoginIdException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.auth.exception;
 
 import kosa.server.common.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/kosa/server/auth/exception/InvalidTokenException.java
+++ b/src/main/java/kosa/server/auth/exception/InvalidTokenException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.auth.exception;
 
 import kosa.server.common.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/kosa/server/auth/exception/LoginFailedException.java
+++ b/src/main/java/kosa/server/auth/exception/LoginFailedException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.auth.exception;
 
 import kosa.server.common.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/kosa/server/auth/exception/PasswordMismatchException.java
+++ b/src/main/java/kosa/server/auth/exception/PasswordMismatchException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.auth.exception;
 
 import kosa.server.common.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/kosa/server/auth/exception/RoleNotFoundException.java
+++ b/src/main/java/kosa/server/auth/exception/RoleNotFoundException.java
@@ -1,0 +1,14 @@
+package kosa.server.auth.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class RoleNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public RoleNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/auth/exception/TokenNotFoundException.java
+++ b/src/main/java/kosa/server/auth/exception/TokenNotFoundException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.auth.exception;
 
 import kosa.server.common.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/kosa/server/auth/oauth2/handler/LoginSuccessHandler.java
+++ b/src/main/java/kosa/server/auth/oauth2/handler/LoginSuccessHandler.java
@@ -3,6 +3,8 @@ package kosa.server.auth.oauth2.handler;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kosa.server.common.code.ErrorCode;
+import kosa.server.common.exception.MemberNotFoundException;
 import kosa.server.common.security.jwt.JwtProvider;
 import kosa.server.common.security.user.CustomUserPrincipal;
 import kosa.server.common.util.CookieUtil;
@@ -37,7 +39,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         // 리프레시 토큰 DB에 저장 (일반 로그인과 동일)
         Member member = memberJpaRepository.findByLoginId(oAuth2User.getName())
-                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다.")); //todo 예외처리
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         LocalDateTime refreshTokenExpireTime = LocalDateTime.now().plusSeconds(JwtProvider.REFRESH_TOKEN_EXPIRE_TIME / 1000);
         RefreshToken newRefreshToken = RefreshToken.builder()
                 .member(member)

--- a/src/main/java/kosa/server/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/kosa/server/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,5 +1,7 @@
 package kosa.server.auth.oauth2.service;
 
+import kosa.server.auth.exception.RoleNotFoundException;
+import kosa.server.common.code.ErrorCode;
 import kosa.server.common.security.user.CustomUserPrincipal;
 import kosa.server.member.entity.Member;
 import kosa.server.member.entity.Role;
@@ -42,7 +44,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         Optional<Member> optionalMember = memberJpaRepository.findByLoginId(customUserPrincipal.getName());
         if (optionalMember.isEmpty()) {
             Role role = roleJpaRepository.findByRoleName(RoleType.USER.getKey())
-                    .orElseThrow(() -> new RuntimeException("해당 권한 타입이 없습니다."));
+                    .orElseThrow(() -> new RoleNotFoundException(ErrorCode.ROLE_NOT_FOUND));
 
             Member member = Member.builder()
                     .loginId(customUserPrincipal.getName())

--- a/src/main/java/kosa/server/auth/service/AuthService.java
+++ b/src/main/java/kosa/server/auth/service/AuthService.java
@@ -5,7 +5,9 @@ import jakarta.mail.internet.MimeMessage;
 import kosa.server.auth.dto.JoinRequestDto;
 import kosa.server.auth.dto.LoginRequestDto;
 import kosa.server.auth.dto.UserInfoDto;
+import kosa.server.auth.exception.*;
 import kosa.server.common.code.ErrorCode;
+import kosa.server.common.exception.MemberNotFoundException;
 import kosa.server.common.security.jwt.JwtProvider;
 import kosa.server.member.entity.EmailVerificationToken;
 import kosa.server.member.entity.Member;
@@ -66,7 +68,7 @@ public class AuthService {
         }
         // 유저 타입 가져오기
         Role role = roleJpaRepository.findByRoleName(RoleType.USER.getKey())
-                .orElseThrow(() -> new RuntimeException("해당 권한 타입이 없습니다."));
+                .orElseThrow(() -> new RoleNotFoundException(ErrorCode.ROLE_NOT_FOUND));
 
         // 멤버 빌더 엔티티 생성(암호화 포함)
         Member newMember = Member.builder()
@@ -91,7 +93,6 @@ public class AuthService {
         log.info("회원가입 성공 ID : {}, loginId : {}, nickname : {}", newMember.getId(), newMember.getLoginId(), newMember.getNickname());
     }
 
-    // todo 예외처리
     public void sendVerificationEmail(String email) throws MessagingException {
         Member member = memberJpaRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/kosa/server/board/exception/AlreadyPartyJoinedException.java
+++ b/src/main/java/kosa/server/board/exception/AlreadyPartyJoinedException.java
@@ -1,0 +1,14 @@
+package kosa.server.board.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AlreadyPartyJoinedException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public AlreadyPartyJoinedException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/board/exception/PartyFullException.java
+++ b/src/main/java/kosa/server/board/exception/PartyFullException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.board.exception;
 
 import kosa.server.common.code.ErrorCode;
 

--- a/src/main/java/kosa/server/board/exception/PartyMemberNotFoundException.java
+++ b/src/main/java/kosa/server/board/exception/PartyMemberNotFoundException.java
@@ -1,0 +1,14 @@
+package kosa.server.board.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class PartyMemberNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public PartyMemberNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/board/exception/PlatformNotFoundException.java
+++ b/src/main/java/kosa/server/board/exception/PlatformNotFoundException.java
@@ -1,0 +1,14 @@
+package kosa.server.board.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class PlatformNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public PlatformNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/board/exception/PostNotFoundException.java
+++ b/src/main/java/kosa/server/board/exception/PostNotFoundException.java
@@ -1,0 +1,14 @@
+package kosa.server.board.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class PostNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public PostNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/board/service/DashboardService.java
+++ b/src/main/java/kosa/server/board/service/DashboardService.java
@@ -5,10 +5,11 @@ import kosa.server.board.dto.response.MyPostResponseDto;
 import kosa.server.board.dto.response.PartyMemberDto;
 import kosa.server.board.entity.PartyMember;
 import kosa.server.board.entity.Post;
+import kosa.server.board.exception.PostNotFoundException;
 import kosa.server.board.repository.PostRepository;
 import kosa.server.common.code.ErrorCode;
 import kosa.server.member.entity.Member;
-import kosa.server.member.exception.InvalidArgumentException;
+import kosa.server.common.exception.MemberNotFoundException;
 import kosa.server.member.repository.jpa.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -33,7 +34,7 @@ public class DashboardService {
     // 파티장 조회 - 상태 필터 포함
     public Page<MyPostResponseDto> readMyPost(String loginId, int page, String sortField, String sortDirection, String statusFilter) {
         Member member = memberJpaRepository.findByLoginId(loginId)
-                .orElseThrow(()->new InvalidArgumentException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(()->new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         Sort sort = getSort(sortField, sortDirection);
         Pageable pageable = PageRequest.of(page, 9, sort);
@@ -68,11 +69,11 @@ public class DashboardService {
     public MyPostOneResponseDto selectParty(String loginId, Long postId) {
         // postId 검증
         Post posts = postRepository.findById(postId)
-                .orElseThrow(()->new InvalidArgumentException(ErrorCode.POST_NOT_FOUND));
+                .orElseThrow(()->new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
 
         // loginId 검증
         Member member = memberJpaRepository.findByLoginId(loginId)
-                .orElseThrow(()->new InvalidArgumentException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(()->new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<PartyMemberDto> members = posts.getPartyMember()
                 .stream()
@@ -163,7 +164,7 @@ public class DashboardService {
     @Transactional
     public void startService(Long postId, int durationMonth) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(()->new InvalidArgumentException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+                .orElseThrow(()->new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
 
         post.startService(durationMonth);
         postRepository.save(post);

--- a/src/main/java/kosa/server/board/service/PlatformService.java
+++ b/src/main/java/kosa/server/board/service/PlatformService.java
@@ -1,18 +1,23 @@
 package kosa.server.board.service;
 
-import kosa.server.board.dto.response.*;
+import kosa.server.board.dto.response.PlatformCategoryDto;
+import kosa.server.board.dto.response.PlatformPostNullResponseDto;
+import kosa.server.board.dto.response.PlatformPostResponseDto;
+import kosa.server.board.dto.response.PlatformResponseDto;
 import kosa.server.board.entity.Platform;
 import kosa.server.board.entity.Post;
+import kosa.server.board.exception.PlatformNotFoundException;
 import kosa.server.board.repository.PlatformRepository;
 import kosa.server.board.repository.PostRepository;
 import kosa.server.common.code.ErrorCode;
-import kosa.server.member.exception.InvalidArgumentException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
 
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class PlatformService {
@@ -23,6 +28,7 @@ public class PlatformService {
     // 전체 플랫폼
     public List<PlatformCategoryDto> getAllPlatforms() {
         List<Platform> platforms = platformRepository.findAllByOrderByCategoryAscNameAsc();
+
         return platforms.stream()
                 .map(platform -> PlatformCategoryDto.builder()
                         .platformId(platform.getId())
@@ -38,6 +44,7 @@ public class PlatformService {
     // 카테고리별 플랫폼
     public List<PlatformCategoryDto> getPlatformsByCategory(int category) {
         List<Platform> platforms = platformRepository.findByCategoryOrderByNameAsc(category);
+
         return platforms.stream()
                 .map(platform -> PlatformCategoryDto.builder()
                         .platformId(platform.getId())
@@ -51,9 +58,9 @@ public class PlatformService {
     }
 
     public List<PlatformPostResponseDto> platformPostList(Long platformId) {
-        List<Post> findPostList = postRepository.findByPlatformId(platformId);
+        List<Post> posts = postRepository.findByPlatformId(platformId);
 
-        return findPostList.stream().map(post -> PlatformPostResponseDto.builder()
+        return posts.stream().map(post -> PlatformPostResponseDto.builder()
                 .postId(post.getId())
                 .nickName(post.getMember().getNickname())
                 .platformName(post.getPlatform().getName())
@@ -70,7 +77,7 @@ public class PlatformService {
 
     public PlatformPostNullResponseDto platformPostNull(Long platformId) {
         Platform platform = platformRepository.findById(platformId)
-                .orElseThrow(()->new InvalidArgumentException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new PlatformNotFoundException(ErrorCode.PLATFORM_NOT_FOUND));
 
         return PlatformPostNullResponseDto.builder()
                 .platformName(platform.getName())
@@ -88,7 +95,7 @@ public class PlatformService {
 
     public PlatformResponseDto getPlatform(Long platformId) {
         Platform findPlatform = platformRepository.findById(platformId)
-                .orElseThrow(() -> new RuntimeException("Platform not found"));
+                .orElseThrow(() -> new PlatformNotFoundException(ErrorCode.PLATFORM_NOT_FOUND));
 
         return PlatformResponseDto.builder()
                 .platformId(findPlatform.getId())

--- a/src/main/java/kosa/server/board/service/PostService.java
+++ b/src/main/java/kosa/server/board/service/PostService.java
@@ -7,15 +7,14 @@ import kosa.server.board.dto.response.*;
 import kosa.server.board.entity.PartyMember;
 import kosa.server.board.entity.Platform;
 import kosa.server.board.entity.Post;
+import kosa.server.board.exception.*;
 import kosa.server.board.repository.PartyMemberRepository;
 import kosa.server.board.repository.PlatformRepository;
 import kosa.server.board.repository.PostRepository;
 import kosa.server.common.code.ErrorCode;
 import kosa.server.mail.service.MailService;
 import kosa.server.member.entity.Member;
-import kosa.server.member.exception.InvalidArgumentException;
-import kosa.server.member.exception.MemberNotFoundException;
-import kosa.server.member.exception.PartyFullException;
+import kosa.server.common.exception.MemberNotFoundException;
 import kosa.server.member.repository.jpa.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,7 +38,7 @@ public class PostService {
     public Long create(PostCreateRequestDto request) {
         //dto를 post로 변환
         Platform createPlatform = platformRepository.findById(request.getPlatformId())
-                .orElseThrow(() -> new RuntimeException("플랫폼을 찾을 수 없습니다."));
+                .orElseThrow(() -> new PlatformNotFoundException(ErrorCode.PLATFORM_NOT_FOUND));
 
         Member findMember = memberJpaRepository.findByLoginId(request.getLoginId())
                 .orElseThrow(()-> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
@@ -73,9 +72,8 @@ public class PostService {
         //Post객체 수정
         //수정한 Post객체 DB에 저장
 
-        // todo 예외 만들기
         Post postToUpdate = postRepository.findById(request.getPostId())
-                .orElseThrow(()->new InvalidArgumentException(ErrorCode.POST_NOT_FOUND));
+                .orElseThrow(()->new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
 
         PostUpdateRequestDto.PostUpdateRequestDtoBuilder editor = postToUpdate.toEditor();
         if (request.getHostPwd() != null) {
@@ -84,7 +82,7 @@ public class PostService {
         if (request.getHostId() != null) {
             editor.hostId(request.getHostId());
         }
-        // todo 프론트에서 인원수와 개월 수를 바꾸지 않는다면 -1을 보내주기로
+        // todo 프론트에서 인원수와 개월 수를 바꾸지 않는다면 0을 보내주기로
         if (request.getDurationMonth() != 0 && request.getDurationMonth() != postToUpdate.getDurationMonth()) {
             editor.durationMonth(request.getDurationMonth());
         }
@@ -94,7 +92,7 @@ public class PostService {
     // 파티 삭제, 나가기
     public void leaveMyPost(Long postId, String loginId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new InvalidArgumentException(ErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
 
         Long memberId = post.getPartyMember().stream()
                 .map(PartyMember::getMember)
@@ -124,11 +122,11 @@ public class PostService {
     // 파티 가입
     public void joinParty(String loginId, Long postId) {
         Member member = memberJpaRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new InvalidArgumentException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         
         // 비관적 락으로 Post 조회
         Post post = postRepository.findByIdWithLock(postId)
-                .orElseThrow(() -> new InvalidArgumentException(ErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
 
         // 파티 정원 체크
         if (post.getCurrentCount() >= post.getPartySize()) {
@@ -139,7 +137,7 @@ public class PostService {
         boolean alreadyJoined = post.getPartyMember().stream()
                 .anyMatch(pm -> pm.getMember().equals(member));
         if (alreadyJoined) {
-            throw new InvalidArgumentException(ErrorCode.PARTY_ALREADY_JOINED);
+            throw new AlreadyPartyJoinedException(ErrorCode.PARTY_ALREADY_JOINED);
         }
 
         PartyMember partyMember = PartyMember.builder()
@@ -155,6 +153,11 @@ public class PostService {
     // 동기 메서드: 데이터 준비
     public void prepareAndSendMail(Long postId) throws UnsupportedEncodingException, MessagingException {
         List<PartyMember> members = partyMemberRepository.findByPostId(postId);
+
+        if (members.isEmpty()) {
+            throw new PartyMemberNotFoundException(ErrorCode.PARTY_MEMBER_NOT_FOUND);
+        }
+
         List<MailTargetResponseDto> targets = members.stream()
                 .map(m -> new MailTargetResponseDto(
                         m.getMember().getEmail(),
@@ -167,7 +170,6 @@ public class PostService {
     }
 
     //만료 상태 업데이트
-    @Transactional
     public void updateExpiredPosts() {
         LocalDateTime today = LocalDateTime.now();
         List<Post> posts = postRepository.findAllByIsExpired("N");

--- a/src/main/java/kosa/server/chat/controller/ChatController.java
+++ b/src/main/java/kosa/server/chat/controller/ChatController.java
@@ -101,7 +101,6 @@ public class ChatController {
         return new ResponseEntity<>(partyMemberResponseDtos, HttpStatus.OK);
     }
 
-    //    /api/chat/room-by-post/{postId}
     @Operation(summary = "postId 기준 채팅방 ID 조회", description = "postId로 연결된 채팅방 ID를 조회합니다.")
     @GetMapping("/api/chat/room-by-post/{postId}")
     public ResponseEntity<?> chatRoomByPostId(@PathVariable Long postId,

--- a/src/main/java/kosa/server/chat/exception/ChatParticipantNotFoundException.java
+++ b/src/main/java/kosa/server/chat/exception/ChatParticipantNotFoundException.java
@@ -1,0 +1,14 @@
+package kosa.server.chat.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ChatParticipantNotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ChatParticipantNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/chat/exception/NotGroupChatException.java
+++ b/src/main/java/kosa/server/chat/exception/NotGroupChatException.java
@@ -1,0 +1,14 @@
+package kosa.server.chat.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotGroupChatException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public NotGroupChatException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/chat/exception/NotMemberOfChatRoomException.java
+++ b/src/main/java/kosa/server/chat/exception/NotMemberOfChatRoomException.java
@@ -1,0 +1,14 @@
+package kosa.server.chat.exception;
+
+import kosa.server.common.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotMemberOfChatRoomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public NotMemberOfChatRoomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/kosa/server/chat/service/ChatService.java
+++ b/src/main/java/kosa/server/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package kosa.server.chat.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import kosa.server.board.entity.Post;
+import kosa.server.board.exception.PostNotFoundException;
 import kosa.server.board.repository.PartyMemberRepository;
 import kosa.server.board.repository.PostRepository;
 import kosa.server.chat.dto.*;
@@ -9,7 +10,10 @@ import kosa.server.chat.entity.ChatMessage;
 import kosa.server.chat.entity.ChatParticipant;
 import kosa.server.chat.entity.ChatRoom;
 import kosa.server.chat.entity.ReadStatus;
+import kosa.server.chat.exception.ChatParticipantNotFoundException;
 import kosa.server.chat.exception.ChatRoomNotFoundException;
+import kosa.server.chat.exception.NotGroupChatException;
+import kosa.server.chat.exception.NotMemberOfChatRoomException;
 import kosa.server.chat.repository.jpa.ChatMessageJpaRepository;
 import kosa.server.chat.repository.jpa.ChatParticipantJpaRepository;
 import kosa.server.chat.repository.jpa.ChatRoomJpaRepository;
@@ -17,7 +21,7 @@ import kosa.server.chat.repository.jpa.ReadStatusJpaRepository;
 import kosa.server.common.code.ErrorCode;
 import kosa.server.member.entity.Member;
 import kosa.server.member.exception.InvalidArgumentException;
-import kosa.server.member.exception.MemberNotFoundException;
+import kosa.server.common.exception.MemberNotFoundException;
 import kosa.server.member.repository.jpa.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -76,7 +80,7 @@ public class ChatService {
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         Post findPost = postJpaRepository.findById(chatRoomCreateDto.getPostId())
-                .orElseThrow(() -> new RuntimeException("post not found"));
+                .orElseThrow(() -> new PostNotFoundException(ErrorCode.POST_NOT_FOUND));
 
         // 채팅방 생성
         ChatRoom chatRoom = ChatRoom.builder()
@@ -131,7 +135,7 @@ public class ChatService {
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         if (chatRoom.getIsGroupChat().equals("N")) {
-            throw new InvalidArgumentException(ErrorCode.NOT_A_GROUP_CHAT);
+            throw new NotGroupChatException(ErrorCode.NOT_A_GROUP_CHAT);
         }
 
         // 이미 참여자 인지 검증
@@ -154,11 +158,11 @@ public class ChatService {
         // 내가 해당 채팅방의 참여자가 아닐경우 에러
         // 채팅방 조회
         ChatRoom chatRoom = chatRoomJpaRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("room cannot be found"));
+                .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 멤버 조회
         Member member = memberJpaRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new EntityNotFoundException("member cannot be found"));
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<ChatParticipant> chatParticipants = chatParticipantJpaRepository.findByChatRoom(chatRoom);
         boolean check = false;
@@ -169,7 +173,7 @@ public class ChatService {
         }
 
         if (!check) {
-            throw new InvalidArgumentException(ErrorCode.NOT_MEMBER_OF_CHAT_ROOM);
+            throw new NotMemberOfChatRoomException(ErrorCode.NOT_MEMBER_OF_CHAT_ROOM);
         }
 
         // 특정 room에 대한 message 조회
@@ -182,11 +186,11 @@ public class ChatService {
     public boolean isRoomParticipant(String email, Long roomId) {
         // 채팅방 조회
         ChatRoom chatRoom = chatRoomJpaRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("room cannot be found"));
+                .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 멤버 조회
         Member member = memberJpaRepository.findByLoginId(email)
-                .orElseThrow(() -> new EntityNotFoundException("member cannot be found"));
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<ChatParticipant> chatParticipants = chatParticipantJpaRepository.findByChatRoom(chatRoom);
         for (ChatParticipant c : chatParticipants) {
@@ -200,11 +204,11 @@ public class ChatService {
     public void messageRead(Long roomId, String loginId) {
         // 채팅방 조회
         ChatRoom chatRoom = chatRoomJpaRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("room cannot be found"));
+                .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 멤버 조회
         Member member = memberJpaRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new EntityNotFoundException("member cannot be found"));
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 채팅룸, 멤버별 읽음여부 채팅 조회
         List<ReadStatus> readStatuses = readStatusJpaRepository.findByChatRoomAndMember(chatRoom, member);
@@ -213,37 +217,20 @@ public class ChatService {
         }
     }
 
-    public List<MyChatListResDto> getMyChatRooms() {
-        Member member = memberJpaRepository.findByLoginId(SecurityContextHolder.getContext().getAuthentication().getName())
-                .orElseThrow(() -> new EntityNotFoundException("member cannot be found"));
-        List<ChatParticipant> chatParticipant = chatParticipantJpaRepository.findAllByMember(member);
-        List<MyChatListResDto> dtos = new ArrayList<>();
-        for (ChatParticipant c : chatParticipant) {
-//            Long count = readStatusJpaRepository.countByChatRoomAndMemberAndIsReadFalse(c.getChatRoom(), member);
-            MyChatListResDto dto = MyChatListResDto.builder()
-                    .roomId(c.getChatRoom().getId())
-                    .roomName(c.getChatRoom().getName())
-//                    .unReadCount(count)
-                    .build();
-            dtos.add(dto);
-        }
-        return dtos;
-    }
-
     public void deleteChatRoom(Long roomId, String loginId) {
         // 채팅방 조회
         ChatRoom chatRoom = chatRoomJpaRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("room cannot be found"));
+                .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 멤버 조회
         Member member = memberJpaRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new EntityNotFoundException("member cannot be found"));
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         if (chatRoom.getIsGroupChat().equals("N")) {
-            throw new InvalidArgumentException(ErrorCode.NOT_A_GROUP_CHAT);
+            throw new NotGroupChatException(ErrorCode.NOT_A_GROUP_CHAT);
         }
 
         ChatParticipant chatParticipant = chatParticipantJpaRepository.findByChatRoomAndMember(chatRoom, member)
-                .orElseThrow(() -> new EntityNotFoundException("참여자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ChatParticipantNotFoundException(ErrorCode.CHAT_PARTICIPANT_NOT_FOUND));
 
         chatParticipantJpaRepository.delete(chatParticipant);
 
@@ -256,49 +243,25 @@ public class ChatService {
     public void leaveChatRoom(Long roomId, String loginId) {
         // 채팅방 조회
         ChatRoom chatRoom = chatRoomJpaRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("room cannot be found"));
+                .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 멤버 조회
         Member member = memberJpaRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new EntityNotFoundException("member cannot be found"));
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         if (chatRoom.getIsGroupChat().equals("N")) {
-            throw new InvalidArgumentException(ErrorCode.NOT_A_GROUP_CHAT);
+            throw new NotGroupChatException(ErrorCode.NOT_A_GROUP_CHAT);
         }
 
         ChatParticipant chatParticipant = chatParticipantJpaRepository.findByChatRoomAndMember(chatRoom, member)
-                .orElseThrow(() -> new EntityNotFoundException("참여자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ChatParticipantNotFoundException(ErrorCode.CHAT_PARTICIPANT_NOT_FOUND));
 
         chatParticipantJpaRepository.delete(chatParticipant);
-    }
-
-    public Long getOrCreatePrivateRoom(Long otherMemberId) {
-        Member member = memberJpaRepository.findByLoginId(SecurityContextHolder.getContext().getAuthentication().getName())
-                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-        Member otherMember = memberJpaRepository.findById(otherMemberId)
-                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-
-        // 나와 상대방이 1:1 채팅에 이미 참석하고 있다면 해당 roomId 리턴
-        Optional<ChatRoom> chatRoom = chatParticipantJpaRepository.findExistingPrivateRoom(member.getId(), otherMember.getId());
-        if (chatRoom.isPresent()) {
-            return chatRoom.get().getId();
-        }
-        // 만약 참석하고 있지 않다면 새로운 채팅방 개설
-        ChatRoom newRoom = ChatRoom.builder()
-                .isGroupChat("N")
-                .name(member.getName() + "-" + otherMember.getName())
-                .build();
-        chatRoomJpaRepository.save(newRoom);
-        // 두사람 모두 참여자로 새롭게 추가
-        addParticipantToRoom(newRoom, member);
-        addParticipantToRoom(newRoom, otherMember);
-
-        return newRoom.getId();
     }
 
     public List<PartyMemberResponseDto> chatRoomMemberList(Long roomId) {
         // RoomId 검증 작업
         chatRoomJpaRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("room cannot be found"));
+                .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // Fetch 조인으로 가져온 뒤 PartyMemberResponseDto List 생성
         return partyMemberRepository.findByChatRoomId(roomId)
@@ -313,7 +276,7 @@ public class ChatService {
     public Long ChatRoomIdByPostId(String memberLoginId, Long postId) {
         // postId 검증
         ChatRoom findChatRoom = chatRoomJpaRepository.findByPostIdAndMemberLoginId(memberLoginId, postId)
-                .orElseThrow(() -> new EntityNotFoundException("post cannot be found"));
+                .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         return findChatRoom.getId();
     }

--- a/src/main/java/kosa/server/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/kosa/server/common/advice/GlobalExceptionHandler.java
@@ -1,8 +1,15 @@
 package kosa.server.common.advice;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kosa.server.auth.exception.*;
+import kosa.server.board.exception.*;
+import kosa.server.chat.exception.ChatParticipantNotFoundException;
+import kosa.server.chat.exception.ChatRoomNotFoundException;
+import kosa.server.chat.exception.NotGroupChatException;
+import kosa.server.chat.exception.NotMemberOfChatRoomException;
 import kosa.server.common.code.ErrorCode;
 import kosa.server.common.dto.ErrorResponseDto;
+import kosa.server.common.exception.MemberNotFoundException;
 import kosa.server.member.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,56 +21,85 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(TokenNotFoundException.class)
-    protected ResponseEntity<ErrorResponseDto> handleTokenNotFoundException(TokenNotFoundException ex, HttpServletRequest request) {
-        ErrorCode errorCode = ex.getErrorCode();
+    // 404 NOT_FOUND - 리소스를 찾을 수 없음 (7개)
+    @ExceptionHandler({
+            MemberNotFoundException.class,
+            PostNotFoundException.class,
+            PlatformNotFoundException.class,
+            ChatRoomNotFoundException.class,
+            ChatParticipantNotFoundException.class,
+            PartyMemberNotFoundException.class,
+            RoleNotFoundException.class
+    })
+    public ResponseEntity<ErrorResponseDto> handleNotFoundException(RuntimeException ex, HttpServletRequest request) {
+        ErrorCode errorCode = getErrorCodeFromException(ex);
 
-        log.warn("[TokenNotFoundException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
-
-        ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
-        return new ResponseEntity<>(response, errorCode.getStatus());
-    }
-
-    @ExceptionHandler(LoginFailedException.class)
-    public ResponseEntity<ErrorResponseDto> loginFailedExceptionHandler(LoginFailedException ex, HttpServletRequest request) {
-        ErrorCode errorCode = ex.getErrorCode();
-
-        log.warn("[LoginFailedException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
-
-        ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
-        return new ResponseEntity<>(response, errorCode.getStatus());
-    }
-
-    @ExceptionHandler(DuplicateMemberException.class)
-    public ResponseEntity<ErrorResponseDto> duplicateMemberExceptionHandler(DuplicateMemberException ex, HttpServletRequest request) {
-        ErrorCode errorCode = ex.getErrorCode();
-
-        log.warn("[DuplicateMemberException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
+        log.warn("[NotFoundException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
 
         ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
-    @ExceptionHandler(MemberNotFoundException.class)
-    public ResponseEntity<ErrorResponseDto> memberNotFoundExceptionHandler(MemberNotFoundException ex, HttpServletRequest request) {
-        ErrorCode errorCode = ex.getErrorCode();
+    // 409 CONFLICT - 중복/충돌 (3개)
+    @ExceptionHandler({
+            DuplicateLoginIdException.class,
+            DuplicateEmailException.class,
+            DuplicateNicknameException.class
+    })
+    public ResponseEntity<ErrorResponseDto> handleConflictException(RuntimeException ex, HttpServletRequest request) {
+        ErrorCode errorCode = getErrorCodeFromException(ex);
 
-        log.warn("[MemberNotFoundException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
+        log.warn("[ConflictException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
 
         ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
+    // 400 BAD_REQUEST - 잘못된 요청/비즈니스 로직 위반 (7개)
+    @ExceptionHandler({
+            PasswordMismatchException.class,
+            LoginFailedException.class,
+            TokenNotFoundException.class,
+            NotGroupChatException.class,
+            NotMemberOfChatRoomException.class,
+            AlreadyPartyJoinedException.class,
+            PartyFullException.class
+    })
+    public ResponseEntity<ErrorResponseDto> handleBadRequestException(RuntimeException ex, HttpServletRequest request) {
+        ErrorCode errorCode = getErrorCodeFromException(ex);
+
+        log.warn("[BadRequestException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
+
+        ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    // 401 UNAUTHORIZED - 인증 실패 (2개)
+    @ExceptionHandler({
+            InvalidTokenException.class,
+            EmailNotVerifiedException.class
+    })
+    public ResponseEntity<ErrorResponseDto> handleUnauthorizedException(RuntimeException ex, HttpServletRequest request) {
+        ErrorCode errorCode = getErrorCodeFromException(ex);
+
+        log.warn("[UnauthorizedException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
+
+        ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    // Validation 오류 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponseDto> MethodArgumentNotValidExceptionHandler(MethodArgumentNotValidException ex, HttpServletRequest request) {
+    public ResponseEntity<ErrorResponseDto> handleValidationException(MethodArgumentNotValidException ex, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
 
-        log.warn("[MethodArgumentNotValidException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
+        log.warn("[ValidationException] {} - Path: {}", errorCode.getMessage(), request.getRequestURI());
 
         ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI(), ex.getBindingResult().getFieldErrors());
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
+    // 전체 예외 처리 (최후 수단)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleInternalServerError(Exception ex, HttpServletRequest request) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
@@ -74,39 +110,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
-    @ExceptionHandler(EmailNotVerifiedException.class)
-    public ResponseEntity<ErrorResponseDto> handleEmailNotVerifiedException(
-            EmailNotVerifiedException ex, HttpServletRequest request) {
-
-        ErrorCode errorCode = ex.getErrorCode();  // 예외에서 직접 errorCode 꺼내기
-
-        log.warn("이메일 인증이 완료되지 않은 사용자 접근: {}", ex.getMessage());
-
-        ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
-        return new ResponseEntity<>(response, errorCode.getStatus());
+    // ErrorCode 추출 헬퍼 메서드
+    private ErrorCode getErrorCodeFromException(RuntimeException ex) {
+        try {
+            return (ErrorCode) ex.getClass().getMethod("getErrorCode").invoke(ex);
+        } catch (Exception e) {
+            log.error("ErrorCode 추출 실패: {}", ex.getClass().getSimpleName());
+            return ErrorCode.INTERNAL_SERVER_ERROR;
+        }
     }
-
-    @ExceptionHandler(DuplicateNicknameException.class)
-    public ResponseEntity<ErrorResponseDto> handleDuplicateNicknameException(
-            DuplicateNicknameException ex, HttpServletRequest request
-    ) {
-        ErrorCode errorCode = ex.getErrorCode();
-
-        log.warn("[DuplicateNicknameException]: {} - Path: {}", ex.getMessage(), request.getRequestURI());
-
-        ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
-        return new ResponseEntity<>(response, errorCode.getStatus());
-    }
-
-    public ResponseEntity<ErrorResponseDto> handleInvalidArgument(
-            InvalidArgumentException ex, HttpServletRequest request) {
-
-        ErrorCode errorCode = ex.getErrorCode();
-
-        log.warn("[InvalidArgumentException]: {}", ex.getMessage(), ex);
-
-        ErrorResponseDto response = ErrorResponseDto.of(errorCode, request.getRequestURI());
-        return new ResponseEntity<>(response, errorCode.getStatus());
-    }
-
 }

--- a/src/main/java/kosa/server/common/code/ErrorCode.java
+++ b/src/main/java/kosa/server/common/code/ErrorCode.java
@@ -8,38 +8,49 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    // Common (1xxx)
+    // Common (Cxxx)
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "유효하지 않은 입력 값입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "지원하지 않는 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부 오류가 발생했습니다."),
 
-    // Member (2xxx)
+    // Member (Mxxx)
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 회원을 찾을 수 없습니다."),
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "M002", "이미 사용 중인 아이디입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "M003", "이미 사용 중인 이메일입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "M004", "비밀번호가 일치하지 않습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "M005", "이미 사용 중인 닉네임입니다."),
 
-    // Auth (3xxx)
+    // Auth (Axxx)
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다."),
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "A003", "인증에 실패했습니다. 유효한 자격 증명이 필요합니다."),
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "A004", "액세스 토큰이 필요합니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "A005", "이메일 인증이 필요합니다."),
 
-    // Chat (4xxx)
+    // Chat (CRxxx)
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "해당 채팅룸을 찾을 수 없습니다."),
     NOT_A_GROUP_CHAT(HttpStatus.BAD_REQUEST, "CR002", "그룹 채팅이 아닙니다."),
     NOT_MEMBER_OF_CHAT_ROOM(HttpStatus.BAD_REQUEST, "CR003", "본인이 속하지 않은 채팅방입니다."),
 
-    // Post (5xxx)
+    // Post (Pxxx)
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "포스트를 찾을 수 없습니다."),
     PARTY_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "P002", "이미 파티에 가입되어 있습니다."),
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "P003", "구독 정보가 없습니다."),
-    PARTY_FULL(HttpStatus.BAD_REQUEST, "P004", "파티 정원이 가득 찼습니다.");
+    PARTY_FULL(HttpStatus.BAD_REQUEST, "P004", "파티 정원이 가득 찼습니다."),
+
+    // Platform (PFXXX)
+    PLATFORM_NOT_FOUND(HttpStatus.NOT_FOUND, "PF001", "플랫폼을 찾을 수 없습니다."),
+
+    // PartyMember(PMXXX)
+    PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PM001", "파티 멤버를 찾을 수 없습니다."),
+
+    // Role (RXXX)
+    ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "역할을 찾을 수 없습니다."),
+
+    //ChatParticipant (CPXXX)
+    CHAT_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CP001", "채팅방 참여자를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String code;
     private final String message;
-
 }

--- a/src/main/java/kosa/server/common/exception/MemberNotFoundException.java
+++ b/src/main/java/kosa/server/common/exception/MemberNotFoundException.java
@@ -1,4 +1,4 @@
-package kosa.server.member.exception;
+package kosa.server.common.exception;
 
 import kosa.server.common.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/kosa/server/member/service/MemberService.java
+++ b/src/main/java/kosa/server/member/service/MemberService.java
@@ -4,7 +4,7 @@ import kosa.server.common.code.ErrorCode;
 import kosa.server.member.dto.response.ProfileResponseDto;
 import kosa.server.member.entity.Member;
 import kosa.server.member.exception.DuplicateNicknameException;
-import kosa.server.member.exception.MemberNotFoundException;
+import kosa.server.common.exception.MemberNotFoundException;
 import kosa.server.member.repository.jpa.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/test/java/kosa/server/board/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/kosa/server/board/service/PostServiceConcurrencyTest.java
@@ -8,7 +8,7 @@ import kosa.server.board.repository.PostRepository;
 import kosa.server.member.entity.Member;
 import kosa.server.member.entity.Role;
 import kosa.server.member.enums.RoleType;
-import kosa.server.member.exception.PartyFullException;
+import kosa.server.board.exception.PartyFullException;
 import kosa.server.member.repository.jpa.MemberJpaRepository;
 import kosa.server.member.repository.jpa.RoleJpaRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/kosa/server/board/service/PostServiceTest.java
+++ b/src/test/java/kosa/server/board/service/PostServiceTest.java
@@ -9,7 +9,7 @@ import kosa.server.board.repository.PostRepository;
 import kosa.server.member.entity.Member;
 import kosa.server.member.entity.Role;
 import kosa.server.member.enums.RoleType;
-import kosa.server.member.exception.PartyFullException;
+import kosa.server.board.exception.PartyFullException;
 import kosa.server.member.repository.jpa.MemberJpaRepository;
 import kosa.server.member.repository.jpa.RoleJpaRepository;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
#61 
- HTTP 상태코드별로 예외 그룹화 (404, 409, 400, 401)
- 코드 중복 제거 및 유지보수성 향상
- 커스텀 익셉션 도메인 패키지 별로 이동
- 누락된 Chat, Board 패키지 예외들 추가
- 미사용 예외 핸들러 제거 (DuplicateMemberException, InvalidArgumentException)
- ErrorCode 추출 헬퍼 메서드 추가